### PR TITLE
Implement a Simple metric filtering 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.43</version>
+        <version>4.20</version>
         <relativePath />
     </parent>
 
@@ -17,7 +17,7 @@
     <properties>
         <revision>1.1</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.138.4</jenkins.version>
+        <jenkins.version>2.302</jenkins.version>
         <java.level>8</java.level>
     </properties>
 
@@ -35,24 +35,34 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>metrics</artifactId>
-            <version>3.1.2.10</version>
+            <version>4.0.2.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
+            <version>2.12.4</version>
         </dependency>
         <dependency>
             <groupId>org.coursera</groupId>
             <artifactId>metrics-datadog</artifactId>
-            <version>1.1.13</version>
+            <version>1.1.14</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jnr</groupId>
+            <artifactId>jnr-ffi</artifactId>
+            <version>2.2.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jnr</groupId>
+            <artifactId>jnr-constants</artifactId>
+            <version>0.10.2</version>
         </dependency>
 
         <!-- test dependencies -->
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.12.2</version>
+            <version>3.20.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/jenkins/metrics/impl/datadog/SimpleMetricFilter.java
+++ b/src/main/java/jenkins/metrics/impl/datadog/SimpleMetricFilter.java
@@ -1,0 +1,36 @@
+package jenkins.metrics.impl.datadog;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.Metric;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.HashSet;
+
+import jenkins.metrics.impl.datadog.MetricsDatadogConfig.PrefixFilter;
+
+public class SimpleMetricFilter implements MetricFilter {
+    private static final Logger LOGGER = Logger.getLogger(SimpleMetricFilter.class.getName());
+    private List<PrefixFilter> prefixes;
+
+    public SimpleMetricFilter(List<PrefixFilter> prefixes) {
+        this.prefixes =
+            prefixes.stream()
+                    .distinct()
+                    .filter(p -> p != null && !p.getPrefix().isEmpty())
+                    .collect(Collectors.toList());
+    }
+
+    public boolean matches(String name, Metric metric) {
+        boolean match =
+        this.prefixes.stream()
+                     .anyMatch(p -> name.startsWith(p.getPrefix()));
+        if (match) {
+            LOGGER.log(Level.FINE, "Metric {0} should be included", new Object[]{name});
+        } else {
+            LOGGER.log(Level.FINE, "Metric {0} does not match the filter", new Object[]{name});
+        }
+        return match;
+    }
+}

--- a/src/main/resources/jenkins/metrics/impl/datadog/Messages.properties
+++ b/src/main/resources/jenkins/metrics/impl/datadog/Messages.properties
@@ -3,3 +3,4 @@ DatadogUdpEndpoint.DescriptorImpl.errors.validation.emptyHost=Empty statsd host
 DatadogUdpEndpoint.DescriptorImpl.errors.validation.invalidHost=Invalid statsd host: unresolvable
 DatadogUdpEndpoint.DescriptorImpl.errors.validation.invalidPort=Invalid port
 Tag.DescriptorImpl.displayName=Key/Value
+PrefixFilter.DescriptorImpl.displayName=Prefix

--- a/src/main/resources/jenkins/metrics/impl/datadog/MetricsDatadogConfig/DatadogUdpEndpoint/config.jelly
+++ b/src/main/resources/jenkins/metrics/impl/datadog/MetricsDatadogConfig/DatadogUdpEndpoint/config.jelly
@@ -9,5 +9,8 @@
   <f:entry title="${%tags}" field="tags">
     <f:repeatableHeteroProperty field="tags" hasHeader="true"/>
   </f:entry>
+  <f:entry title="${%prefixFilters}" field="prefixFilters">
+    <f:repeatableHeteroProperty field="prefixFilters" hasHeader="false"/>
+  </f:entry>
   <f:validateButton title="${%testConnectivity}" progress="${%testing}" method="testUdpEndpoint" with="statsdHost,port" />
 </j:jelly>

--- a/src/main/resources/jenkins/metrics/impl/datadog/MetricsDatadogConfig/DatadogUdpEndpoint/config.properties
+++ b/src/main/resources/jenkins/metrics/impl/datadog/MetricsDatadogConfig/DatadogUdpEndpoint/config.properties
@@ -1,5 +1,6 @@
 statsdHost=Statsd host
 port=Port
 tags=Tags
+prefixFilters=Metric Prefixes
 testConnectivity=Test connectivity
 testing=Testing...

--- a/src/main/resources/jenkins/metrics/impl/datadog/MetricsDatadogConfig/DatadogUdpEndpoint/help-prefixFilters.html
+++ b/src/main/resources/jenkins/metrics/impl/datadog/MetricsDatadogConfig/DatadogUdpEndpoint/help-prefixFilters.html
@@ -1,0 +1,5 @@
+<div>
+List of prefixes to match the metric names. Only matching metrics will be sent to Datadog.<br>
+Check all the available metrics in the <b><a href="https://plugins.jenkins.io/metrics/">Metrics Plugin Page</a></b><br><br>
+e,g: If you want to include only the <b>vm.memory</b> and the <b>http</b> metrics add to MetricPrefixes with that values.
+</div>

--- a/src/main/resources/jenkins/metrics/impl/datadog/MetricsDatadogConfig/PrefixFilter/config.jelly
+++ b/src/main/resources/jenkins/metrics/impl/datadog/MetricsDatadogConfig/PrefixFilter/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="${%Prefix}" field="prefix">
+    <f:textbox/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/jenkins/metrics/impl/datadog/MetricsDatadogConfig/PrefixFilter/config.properties
+++ b/src/main/resources/jenkins/metrics/impl/datadog/MetricsDatadogConfig/PrefixFilter/config.properties
@@ -1,0 +1,1 @@
+Prefix=Prefix

--- a/src/test/java/jenkins/metrics/impl/datadog/DatadogReporterRegistryTest.java
+++ b/src/test/java/jenkins/metrics/impl/datadog/DatadogReporterRegistryTest.java
@@ -20,8 +20,8 @@ public class DatadogReporterRegistryTest {
         rr.then(r -> {
             MetricsDatadogConfig config = MetricsDatadogConfig.instanceOrDie();
             List<MetricsDatadogConfig.DataDogEndpoint> list = Arrays.asList(
-                    new DatadogUdpEndpoint(null, "localhost", 8125),
-                    new DatadogUdpEndpoint(null, "localhost", 18125)
+                new DatadogUdpEndpoint(null, null, "localhost", 8125),
+                new DatadogUdpEndpoint(null, null, "localhost", 18125)
             );
 
             config.setEndpointsList(list);
@@ -31,8 +31,8 @@ public class DatadogReporterRegistryTest {
         rr.then(r -> {
             MetricsDatadogConfig config = MetricsDatadogConfig.instanceOrDie();
             List<MetricsDatadogConfig.DataDogEndpoint> list = Arrays.asList(
-                    new DatadogUdpEndpoint(null, "localhost", 8125),
-                    new DatadogUdpEndpoint(null, "invalid", 999999)
+                new DatadogUdpEndpoint(null, null, "localhost", 8125),
+                new DatadogUdpEndpoint(null, null, "invalid", 999999)
             );
             config.setEndpointsList(list);
             r.configRoundtrip();

--- a/src/test/java/jenkins/metrics/impl/datadog/MetricsDatadogConfigTest.java
+++ b/src/test/java/jenkins/metrics/impl/datadog/MetricsDatadogConfigTest.java
@@ -30,8 +30,8 @@ public class MetricsDatadogConfigTest {
     public void testConfigRoundTrip() throws Exception {
         MetricsDatadogConfig config = MetricsDatadogConfig.instanceOrDie();
         List<MetricsDatadogConfig.DataDogEndpoint> list = Arrays.asList(
-                new DatadogUdpEndpoint(null, "localhost", 8125),
-                new DatadogUdpEndpoint(null, "invalid", 999999)
+            new DatadogUdpEndpoint(null, null, "localhost", 8125),
+            new DatadogUdpEndpoint(null, null, "invalid", 999999)
         );
         config.setEndpointsList(list);
         j.configRoundtrip();

--- a/src/test/java/jenkins/metrics/impl/datadog/SimpleMetricFilterTest.java
+++ b/src/test/java/jenkins/metrics/impl/datadog/SimpleMetricFilterTest.java
@@ -1,0 +1,50 @@
+package jenkins.metrics.impl.datadog;
+
+import jenkins.metrics.impl.datadog.MetricsDatadogConfig.DatadogUdpEndpoint;
+import jenkins.metrics.impl.datadog.MetricsDatadogConfig.PrefixFilter;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleMetricFilterTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testMatches() throws Exception {
+        List<PrefixFilter> prefixFilters = Arrays.asList(
+            new PrefixFilter("vm"),
+            new PrefixFilter("http")
+        );
+        SimpleMetricFilter mf = new SimpleMetricFilter(prefixFilters);
+        assertThat(mf.matches("vm.memory.total", null)).isTrue();
+        assertThat(mf.matches("http.requests.total", null)).isTrue();
+        assertThat(mf.matches("jenkins.job.finished", null)).isFalse();
+    }
+
+    public void testConfigRoundTrip() throws Exception {
+        MetricsDatadogConfig config = MetricsDatadogConfig.instanceOrDie();
+        List<PrefixFilter> prefixFilters = Arrays.asList(
+            new PrefixFilter("vm"),
+            new PrefixFilter("http")
+        );
+        List<MetricsDatadogConfig.DataDogEndpoint> list = Arrays.asList(
+            new DatadogUdpEndpoint(prefixFilters, null, "localhost", 8125),
+            new DatadogUdpEndpoint(prefixFilters, null, "invalid", 999999)
+        );
+
+
+        config.setEndpointsList(list);
+        j.configRoundtrip();
+        // reload list from disk:
+        List<MetricsDatadogConfig.DataDogEndpoint> reloadedList = new MetricsDatadogConfig().getEndpointsList().toList();
+        assertThat(reloadedList).isEqualTo(list);
+    }
+
+}


### PR DESCRIPTION
## Description 
This PR adds a basic metric filtering to enable the plugin to send just a subset of metrics to Datadog. This is useful when the jenkins datadog-plugin is used to not duplicate metrics in Datadog.

A new configuration element `Prefix Filter` is set to add all the prefixes we want to send to Datadog. The filtering is made through an implementation of the the MetricFilter interface set into the DataDogReporter with the `.filter()` method. 

I have also updated the maven dependencies. 

If you have any suggestion or improvement, let me know.
 
